### PR TITLE
Changed blockshibe url to archival link.

### DIFF
--- a/graveyard.csv
+++ b/graveyard.csv
@@ -1,6 +1,6 @@
 name, description, website, write-up 
 
-Block Shibe, BlockShibe is a web app that tracks Dogecoin block statistics in real time, https://blockshibe.net/, -
+Block Shibe, BlockShibe is a web app that tracks Dogecoin block statistics in real time, https://web.archive.org/web/20220803041125/https://blockshibe.net/, -
 
 SuchList, A marketplace where you can buy and sell things for Dogecoin, https://web.archive.org/web/20140625124523/https://suchlist.com/, -
 


### PR DESCRIPTION
Making this change to accommodate the real possibility that this URL could become inactive, get transferred to someone else for other uses or get pointed elsewhere by the current owner.