### PR TITLE
Added DogePulse

### DIFF
--- a/graveyard.csv
+++ b/graveyard.csv
@@ -21,3 +21,5 @@ DogeBucket, Receive crowdfunding or dogecoin tips for just about anything, https
 DogeTunes, Buy music with Ðogecoin in the internet!, https://web.archive.org/web/20141013142747/http://dogetunes.tytos.se/p/about, -
 
 PartyDoge, Buy superior party and promotional products with Dogecoin, https://web.archive.org/web/20140311123909/http://www.partydoge.com/about/, -
+
+Dogepulse, One dashboard for all Dogecoin stats, https://web.archive.org/web/20141104115921/http://dogepulse.com/, -

--- a/graveyard.csv
+++ b/graveyard.csv
@@ -22,4 +22,4 @@ DogeTunes, Buy music with Ðogecoin in the internet!, https://web.archive.org/we
 
 PartyDoge, Buy superior party and promotional products with Dogecoin, https://web.archive.org/web/20140311123909/http://www.partydoge.com/about/, -
 
-Dogepulse, One dashboard for all Dogecoin stats, https://web.archive.org/web/20141104115921/http://dogepulse.com/, -
+DogePulse, One dashboard for all Dogecoin stats, https://web.archive.org/web/20141104115921/http://dogepulse.com/, -


### PR DESCRIPTION
DogePulse.com is now a website servicing a different project on Pulsechain. Use the web.archive link provided to access the project page.